### PR TITLE
Increase `maxVersionsShown`

### DIFF
--- a/src/PackageCard.tsx
+++ b/src/PackageCard.tsx
@@ -35,7 +35,7 @@ const MemoVersionDownloadChart: React.FC<PackageCardProps> = React.memo(
           <VersionDownloadChart
             identifier={identifier}
             versionFilter={versionFilter}
-            maxVersionsShown={6}
+            maxVersionsShown={4}
           />
         );
     }


### PR DESCRIPTION
This increases the number of "top versions shown" for patch. Would be great to make this controllable in the UI, but for now we can give a better default value.

## Before

<img src="https://user-images.githubusercontent.com/835219/138592016-73207071-b21b-4444-b5ca-01d7e956ee57.png" width="600">
<img src="https://user-images.githubusercontent.com/835219/138592044-db46c4de-ec56-4ebb-8868-3c481e58fa09.png" width="300">

## After
<img src="https://user-images.githubusercontent.com/835219/138592064-5f6ed09f-4a33-42a6-86e8-6d35a57aec03.png" width="600">
<img src="https://user-images.githubusercontent.com/835219/138592082-e8aff68a-81f0-4c0d-add3-be429b0db810.png" width="300">
