### PR TITLE
Filter date range to "popular versions" crteria

### DIFF
--- a/src/PackageCard.tsx
+++ b/src/PackageCard.tsx
@@ -15,14 +15,14 @@ export type PackageCardProps = {
   versionFilter: VersionFilter;
 };
 
-function maxVersions(versionFilter: VersionFilter) {
+function maxDays(versionFilter: VersionFilter) {
   switch (versionFilter) {
     case "major":
-      return 8;
+      return 60;
     case "patch":
-      return 9;
+      return 30;
     case "prerelease":
-      return 7;
+      return 14;
   }
 }
 
@@ -77,7 +77,8 @@ const PackageCard: React.FC<PackageCardProps> = (props) => {
         <div className={styles.chartContainer}>
           <VersionDownloadChart
             historyPoints={historyPoints}
-            maxVersionsShown={maxVersions(props.versionFilter)}
+            maxDaysShown={maxDays(props.versionFilter)}
+            maxVersionsShown={7}
             measurementTransform={
               showAsPercentage ? "percentage" : "totalDownloads"
             }

--- a/src/VersionDownloadChart.tsx
+++ b/src/VersionDownloadChart.tsx
@@ -26,8 +26,12 @@ export type VersionDownloadChartProps = {
   historyPoints: HistoryPoint[];
 
   /**
-   * Number of versions shown at once, with the most popular versions always
-   * showing up
+   * Maximum duration the graph will show, in days
+   */
+  maxDaysShown?: number;
+
+  /**
+   * Maximum separate versions show, attempting to show most popular versions.
    */
   maxVersionsShown?: number;
 
@@ -54,6 +58,7 @@ export type VersionDownloadChartProps = {
 
 const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
   historyPoints,
+  maxDaysShown,
   maxVersionsShown,
   showLegend,
   showTooltip,
@@ -61,7 +66,7 @@ const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
   versionLabeler,
 }) => {
   const topRawDataPoints = maxVersionsShown
-    ? filterTopN(historyPoints, maxVersionsShown, 20 /*windowInDays*/)
+    ? filterTopN(historyPoints, maxVersionsShown, maxDaysShown ?? 30)
     : historyPoints;
 
   const datapoints =
@@ -268,6 +273,10 @@ function filterTopN(
   const pointsWithZero: HistoryPoint[] = [];
 
   for (const date of datesAscending) {
+    if (date < earliestAllowableDate) {
+      continue;
+    }
+
     for (const topVersion of topVersionsInOrder) {
       const existingPoint = pointsByDate
         .get(date)!


### PR DESCRIPTION
This adds better logic for determining date ranges to show, to not give a misleading representation of data. Instead of tweaking version count by release channel, we manipulate the time window, to achieve the given resolution we want.

Before:
<img width="994" alt="image" src="https://user-images.githubusercontent.com/835219/147141780-eb34cd00-44d4-46df-8b51-d983d2c46132.png">
<img width="989" alt="image" src="https://user-images.githubusercontent.com/835219/147142124-f98b32c0-27fc-4dd9-a033-b9d1dbf848c5.png">


After:
<img width="995" alt="image" src="https://user-images.githubusercontent.com/835219/147141812-bc031cd9-8306-4d1c-a572-e08636eb4ffa.png">
<img width="996" alt="image" src="https://user-images.githubusercontent.com/835219/147142102-af5c2162-3e28-4185-816a-42f708dd5b76.png">

