### PR TITLE
format download count, allow axis autosizing

### DIFF
--- a/src/components/VersionDownloadChart.tsx
+++ b/src/components/VersionDownloadChart.tsx
@@ -186,7 +186,7 @@ const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
                 }
               : {
                   domain: ["auto", "auto"],
-                  tickFormatter: (count) => count.toLocaleString(),
+                  tickFormatter: formatDownloadCountTicks,
                 })}
           />
 
@@ -236,6 +236,18 @@ const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
     </div>
   );
 };
+
+function formatDownloadCountTicks(count: number) {
+  if (!count) {
+    return "";
+  } else if (count >= 1000000) {
+    return `${(count / 1000000).toLocaleString()} m`;
+  } else if (count >= 1000) {
+    return `${(count / 1000).toLocaleString()} k`;
+  } else {
+    return count.toLocaleString();
+  }
+}
 
 function calculateDateTicks(dates: number[], maxTicks: number): number[] {
   if (maxTicks === 0) {

--- a/src/styles/VersionDownloadChart.styles.ts
+++ b/src/styles/VersionDownloadChart.styles.ts
@@ -61,13 +61,11 @@ const styles: VersionDownloadChartStyle = ({ theme, unit } = {}) => ({
     strokeDasharray: "1 1",
   },
   xAxis: {
-    height: 32,
     tickLine: false,
     tickMargin: 10,
     tick: { fill: theme?.semanticColors.bodyText },
   },
   yAxis: {
-    width: 80,
     tickLine: false,
     tickMargin: 10,
     tickSize: 0,


### PR DESCRIPTION
# Why

Currently values on the download count axis varies from hundreds to millions, also printing the whole number reduces the space for the chart itself.

# How

This PR adds custom tick formatter for the download count axis, which aims to shorten the labels and also hides `0` for the clarity.

I have also removed the fixed axis widths, to allow ResoponsiveContainer to calculate those according to the content width. This also results in increased chart area in tile.

# Preview (before & after)
<img width="1134" alt="Screenshot 2022-01-28 221849" src="https://user-images.githubusercontent.com/719641/151623046-e5df0882-e5f4-4d13-98f6-91b01d6335ff.png">
<img width="1142" alt="Screenshot 2022-01-28 221906" src="https://user-images.githubusercontent.com/719641/151623054-1150af4e-5265-48a7-a0cb-7ca37840c53a.png">


