### PR TITLE
add total value to the chart tooltips

### DIFF
--- a/src/components/VersionTooltip.tsx
+++ b/src/components/VersionTooltip.tsx
@@ -89,6 +89,16 @@ export const VersionTooltipContent: React.FC<
                 </li>
               );
             })}
+            <li key="sum" className={styles.versionsListItem}>
+              <Text variant="small" className={styles.versionLabel}>
+                Total
+              </Text>
+              <Text variant="small" className={styles.versionCount}>
+                {reversedItems
+                  .reduce((prev, curr) => prev + (curr.value || 0), 0)
+                  .toLocaleString()}
+              </Text>
+            </li>
           </ul>
         );
 


### PR DESCRIPTION
# Why

Currently the total value of downloads per data chunk is not visible anywhere, so I thought that adding this to the tooltip could be a nice addition.

# How

This PR adds one more row ate the end on the tooltip which includes the sum for a given data chunk. I thought about disabling it in percentage mode, but finally I leave it in. Feel free to change that I you have a stron opinion on that.

# Preview

![xx](https://user-images.githubusercontent.com/719641/151623694-b80ead94-96bd-4576-b8ed-5360a7545d8c.gif)