### PR TITLE
Remove Expo prerelease version labeler

### DIFF
--- a/src/PackageDescription.ts
+++ b/src/PackageDescription.ts
@@ -69,18 +69,6 @@ function isAlphaOrBeta(version: string): boolean {
   return version.includes("alpha") || version.includes("beta");
 }
 
-function alphaBetaVersionLabeler(version: string): string {
-  const major = version.split(".")![0];
-
-  if (version.includes("alpha")) {
-    return `${major}@alpha`;
-  } else if (version.includes("beta")) {
-    return `${major}@beta`;
-  }
-
-  return version;
-}
-
 const isNightly = (v: string) => semver.lt(v, "0.0.0");
 const minVersion = (v: string, min: string) =>
   semver.gte(v, `${min}.0`, {
@@ -116,7 +104,6 @@ const packagesLiteral = {
   expo: {
     friendlyName: "Expo",
     versionFilter: (v: string) => minVersion(v, "40.0") || isAlphaOrBeta(v),
-    versionLabeler: alphaBetaVersionLabeler,
   },
 };
 


### PR DESCRIPTION
We don't actually need to apply any custom labels for Expo pre-release versions at the moment. We may revisit this in the future when we adopt a nightly schedule.

<img width="1492" alt="Screen Shot 2022-01-28 at 2 54 47 PM" src="https://user-images.githubusercontent.com/90494/151632799-97604fc7-7594-4495-a70f-6f61610929b8.png">
