### PR TITLE
tweak the chart tooltip appearance

### DIFF
--- a/src/components/VersionTooltip.tsx
+++ b/src/components/VersionTooltip.tsx
@@ -76,11 +76,11 @@ export const VersionTooltipContent: React.FC<
 
               return (
                 <li key={i} className={styles.versionsListItem}>
-                  <div
-                    className={styles.versionColorIndicator}
-                    style={{ backgroundColor: colorChipColor }}
-                  />
-                  <Text variant="small" className={styles.versionLabel}>
+                  <Text
+                    variant="small"
+                    className={styles.versionLabel}
+                    style={{ color: colorChipColor }}
+                  >
                     {entry.name}
                   </Text>
                   <Text variant="small" className={styles.versionCount}>

--- a/src/styles/VersionDownloadChart.styles.ts
+++ b/src/styles/VersionDownloadChart.styles.ts
@@ -42,7 +42,7 @@ export type VersionDownloadChartStyle = (opts?: {
 
 const styles: VersionDownloadChartStyle = ({ theme, unit } = {}) => ({
   areaChart: {
-    margin: { top: 15, right: 32, bottom: 5 },
+    margin: { top: 15, right: 28, bottom: 5 },
   },
   area: {
     isAnimationActive: false,
@@ -52,7 +52,7 @@ const styles: VersionDownloadChartStyle = ({ theme, unit } = {}) => ({
   },
   responsiveContainer: {
     width: "100%",
-    height: 220,
+    height: 228,
   },
   grid: {
     stroke: theme?.isInverted
@@ -62,6 +62,7 @@ const styles: VersionDownloadChartStyle = ({ theme, unit } = {}) => ({
   },
   xAxis: {
     tickLine: false,
+    tickSize: 4,
     tickMargin: 10,
     tick: { fill: theme?.semanticColors.bodyText },
   },
@@ -70,6 +71,7 @@ const styles: VersionDownloadChartStyle = ({ theme, unit } = {}) => ({
     tickMargin: 10,
     tickSize: 0,
     tickCount: 5,
+    width: 52,
     tick: { fill: theme?.semanticColors.bodyText },
   },
   tooltip: {

--- a/src/styles/VersionTooltip.module.scss
+++ b/src/styles/VersionTooltip.module.scss
@@ -3,19 +3,20 @@
 .frame {
   @include ms-depth-16;
 
-  padding: 10px;
+  padding: 6px 10px;
 }
 
 .date {
-  display: inline-block;
-
   @include ms-fontWeight-semibold;
-  padding-bottom: 10px;
+  display: block;
+  text-align: center;
+  padding-bottom: 4px;
 }
 
 .versionsList {
-  padding: 0 0 5px 0;
+  padding: 0;
   margin: 0;
+  min-width: 128px;
 }
 
 .versionsListItem {
@@ -23,14 +24,6 @@
   padding: 0;
   display: flex;
   align-items: center;
-}
-
-.versionColorIndicator {
-  display: inline-block;
-  width: 4px;
-  height: 1.5em;
-  margin-right: 4px;
-  vertical-align: middle;
 }
 
 .versionLabel {

--- a/src/styles/VersionTooltip.module.scss
+++ b/src/styles/VersionTooltip.module.scss
@@ -20,7 +20,7 @@
 }
 
 .versionsListItem {
-  height: 1.75em;
+  height: 1.6em;
   padding: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Why

:warning: Alert: Subjective change! It's fine if you don't like it. 😉 

Currently IMO the tooltips lacks a bit of clarity, mainly due to the color indicator at the beginning of entry and a bit cramped visually data.

# How 

This PR aims to improve the clarity/readability by removing the indicator, applying the color to the version name (since colors are already calculated in a way which ensures good contrast) and adjusting the spacing in and size of the Tooltip container.

I have also centered the date, because I feel like this match the centered headings of the tiles.

There was an attempt to color the values instead of the labels, but due to font weight it looks better and maintains the readability better on the labels. Coloring both parts also feels like too much of the color, it was hard to maintain attention on a given row.

# Preview

![clr2](https://user-images.githubusercontent.com/719641/151636181-d59e1ae6-679c-4c76-9250-410e5c0aa6c8.gif)
