### PR TITLE
Fix `,json` typo

### DIFF
--- a/scripts/updateHistory.ts
+++ b/scripts/updateHistory.ts
@@ -192,7 +192,7 @@ async function recordVersionCounts(
       versions: counts,
     });
 
-    const timedHistoryPath = historyTimestampPath(`${pkg},json`);
+    const timedHistoryPath = historyTimestampPath(`${pkg}.json`);
     await fs.mkdir(path.dirname(timedHistoryPath), { recursive: true });
     await fs.writeFile(timedHistoryPath, JSON.stringify(counts, null, 2));
   }


### PR DESCRIPTION
I was just looking into the files (usual procrastination lol) and found out that the JSON data are named as ,json instead of .json.