### PR TITLE
allow user to turn on and off chart series

### DIFF
--- a/src/components/VersionDownloadChart.tsx
+++ b/src/components/VersionDownloadChart.tsx
@@ -97,6 +97,7 @@ const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
   const styles = styleProps({ theme, unit });
 
   const [legendElement, setLegendElement] = useState<HTMLDivElement>();
+  const [hiddenSeries, setHiddenSeries] = useState<string[]>([]);
 
   const filteredHistory = React.useMemo(
     () => filterTopN(history, maxVersionsShown ?? 5, maxDaysShown ?? 30),
@@ -209,6 +210,8 @@ const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
                     <VersionLegend
                       payload={payload}
                       versionHues={versionHues}
+                      hiddenSeries={hiddenSeries}
+                      setHiddenSeries={setHiddenSeries}
                     />
                   ),
                   legendElement
@@ -222,7 +225,11 @@ const VersionDownloadChart: React.FC<VersionDownloadChartProps> = ({
               {...styles.area}
               name={name}
               key={name}
-              dataKey={(datapoint) => datapoint.versionCounts[dataKey]}
+              dataKey={(datapoint) =>
+                hiddenSeries.includes(dataKey)
+                  ? undefined
+                  : datapoint.versionCounts[dataKey]
+              }
               stackId="1"
               fill={fill}
               fillOpacity={1}

--- a/src/components/VersionLegend.tsx
+++ b/src/components/VersionLegend.tsx
@@ -7,21 +7,28 @@ import { colorForHue } from "../chartColor";
 type VersionLegendProps = {
   payload: Payload[];
   versionHues: Record<string, number>;
+  hiddenSeries: string[];
+  setHiddenSeries: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 const VersionLegend: React.FC<VersionLegendProps> = ({
   payload,
   versionHues,
+  hiddenSeries,
+  setHiddenSeries,
 }) => {
   return (
     <ThemeContext.Consumer>
       {(theme) => (
         <div className={styles.versionsListContainer}>
           <ul className={styles.versionsList}>
-            {payload.map((entry) => {
-              const colorChipColor = theme
+            {payload.map(({ value, color }) => {
+              const isHidden = hiddenSeries.includes(value);
+              const colorChipColor = isHidden
+                ? theme?.semanticColors.buttonBackgroundDisabled
+                : theme
                 ? colorForHue(
-                    versionHues[entry.value!],
+                    versionHues[value!],
                     theme.isInverted
                       ? { variant: "dark", targetLuminance: "contrasts-dark" }
                       : {
@@ -29,16 +36,34 @@ const VersionLegend: React.FC<VersionLegendProps> = ({
                           targetLuminance: "contrasts-light",
                         }
                   )
-                : entry.color!;
+                : color!;
 
               return (
-                <li key={entry.value} className={styles.versionsListItem}>
+                <li
+                  key={value}
+                  className={styles.versionsListItem}
+                  onClick={() =>
+                    setHiddenSeries((hiddenSeries: string[]) =>
+                      hiddenSeries.includes(value)
+                        ? hiddenSeries.filter((key: string) => key !== value)
+                        : hiddenSeries.concat(value)
+                    )
+                  }
+                >
                   <div
                     className={styles.versionColorIndicator}
                     style={{ backgroundColor: colorChipColor }}
                   />
-                  <Text variant="small" className={styles.versionLabel}>
-                    {entry.value}
+                  <Text
+                    variant="small"
+                    className={styles.versionLabel}
+                    style={
+                      isHidden
+                        ? { color: theme?.semanticColors.buttonTextDisabled }
+                        : {}
+                    }
+                  >
+                    {value}
                   </Text>
                 </li>
               );

--- a/src/styles/VersionLegend.module.scss
+++ b/src/styles/VersionLegend.module.scss
@@ -24,12 +24,14 @@
   padding: 0;
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .versionColorIndicator {
   display: inline-block;
-  width: 4px;
-  height: 1em;
+  width: 8px;
+  height: 8px;
+  border-radius: 100%;
   margin-right: 4px;
   vertical-align: middle;
 }


### PR DESCRIPTION
# Why

I think that this feature will be useful for the website users. With the current code it can be achieve quite easily, so why not do this. 😉 

# How

This PR adds an ability to turn ON and OFF selected series in chart by the users.

I have also tweaked the legend entry indicator appearance a bit. I have also thought about switching to the more "button-like" appearance, something like "Pills", but I have decided to leave it for the conversation in the future.

# TODO

* I'm also not completely sold on the inactive series indicator color, but I'm that familiar with FluentUI, it was the best theme variable which I can find, so feel free to adjust that or suggest me a better one here. Also adding hover effect might be something worth working on.
* Currently the code did not work for `nightly` and `canary` series due to difference in visible name vs `dataKey`. I will look into this issue soon. If you have any suggestions or tips how the best fix that please let me know.

# Preview
![hide](https://user-images.githubusercontent.com/719641/152542888-9627471a-4ebe-43f0-b2ff-408c9b18f6a6.gif)
