### PR TITLE
Change how popular major versions determined

### DIFF
--- a/src/components/PackageCard.tsx
+++ b/src/components/PackageCard.tsx
@@ -42,6 +42,17 @@ function maxDays(versionFilter: VersionFilter) {
   }
 }
 
+function popularDuring(versionFilter: VersionFilter): "most-recent" | "all" {
+  switch (versionFilter) {
+    case "major":
+      return "most-recent";
+    case "patch":
+      return "all";
+    case "prerelease":
+      return "all";
+  }
+}
+
 const ChartFallback: React.FC = () => (
   <div className={styles.silhouette}>
     <div className={styles.shimmerRoot}>
@@ -109,6 +120,7 @@ const PackageCard: React.FC<PackageCardProps> = ({
             history={dataIsReady ? history : undefined}
             maxDaysShown={maxDays(versionFilter)}
             maxVersionsShown={6}
+            popularDuring={popularDuring(versionFilter)}
             maxTicks={4}
             unit={showAsPercentage ? "percentage" : "totalDownloads"}
             versionLabeler={packageDesc.versionLabeler}


### PR DESCRIPTION
See #25

The current methods of determining popularity is to sum, then rank, all polled download rates over the full window where a chart shows versions. This effectively tries to show the versions with the most area throughout the entire chart.

When we release a new version, we're more interested in what happens in a recent time-period, e.g. the most recent week, as npm is able to most granularly measure.

This biasing doesn't work well for prerelease versions, which may not have downloads for more than a couple of days to use as ranking, but the approach of ranking based on most recent polling will show what we want for longer-lived versions, such as new major releases.

0.68 shows up after this change, though there's still a data spike issue.