### PR TITLE
Cleanup TypeScript config

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,18 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
-    "lib": [
-      "dom",
-      "dom.iterable"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "noImplicitAny": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "esnext"
   },
-  "include": [
-    "src",
-    "scripts",
-    "vite.config.ts"
-  ]
+  "exclude": ["build"]
 }


### PR DESCRIPTION
- Cleans up leftovers from react-scripts
- Teaches TypeScript how to deal with SCSS modules - and thus, fixes errors thrown by TypeScript when importing one
- Simplifies and modernizes config
  - target is irrelevant, as it's Vite that handles the compilation. So it's best to have it set to esnext to avoid imaginary problems.
  - allowJs is not needed, because there's no JS. Yay!
  - added noImplicitAny and strictNullChecks for even more strictness. So far so good.

After this change, running `yarn tsc --noEmit` can, separately or as a CI step, validate our code.