### PR TITLE
Add test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "generate-assets": "ts-node --transpile-only ./scripts/generateAssets.ts",
-    "update-history": "ts-node --transpile-only ./scripts/updateHistory.ts"
+    "update-history": "ts-node --transpile-only ./scripts/updateHistory.ts",
+    "tsc": "tsc --noEmit",
+    "test": "yarn lint && yarn prettier && yarn tsc"
   },
   "dependencies": {
     "@fluentui/react": "^8.48.1",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,18 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
-    "lib": [
-      "dom",
-      "dom.iterable"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "noImplicitAny": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "esnext"
   },
-  "include": [
-    "src",
-    "scripts",
-    "vite.config.ts"
-  ]
+  "exclude": ["build"]
 }


### PR DESCRIPTION
Now that we cleared TypeScript errors in #33, we can actually run `tsc` and get exit 0. We have also added Prettier command in #36. So, we can now lint, format, and type check our code. So, we can have `test` command that does all of that stuff. Next stop - CI!