### PR TITLE
Remove react-dom/experimental imports

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -12,7 +12,6 @@ import {
 } from "../styles/Themes";
 import { ThemeProvider } from "@fluentui/react";
 
-import type {} from "react/experimental";
 import usePersistentState from "../hooks/usePersistentState";
 import useSearchParamsState from "../hooks/useSearchParamsState";
 

--- a/src/components/PackageCard.tsx
+++ b/src/components/PackageCard.tsx
@@ -11,7 +11,6 @@ import { lightTheme } from "../styles/Themes";
 import useHistory from "../hooks/useHistory";
 import TooltipButton from "./TooltipButton";
 
-import type {} from "react/experimental";
 import React from "react";
 import usePersistentState from "../hooks/usePersistentState";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,8 +4,6 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./components/App";
 
-import type {} from "react-dom/experimental";
-
 HistoryReader.prefetch();
 
 createRoot(document.getElementById("app")!).render(


### PR DESCRIPTION
Now that since #44 we're using correct @types/react(-dom) version, we can get rid of `react-dom/experimental` imports.