### PR TITLE
Preload fonts from static2.sharepointonline.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,24 @@
     <meta name="description" content="React Native Version Share" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
+    <link
+      rel="preload"
+      href="https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.woff2"
+      as="font"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.woff2"
+      as="font"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-bold.woff2"
+      as="font"
+      crossorigin
+    />
     <title>React Native Version Share</title>
   </head>
 


### PR DESCRIPTION
Previously fonts _started_ loading only after JS has been downloaded and evaluated. And there's _still_ quite a lot of JS. This caused text on page to render with fallback font first, then jump to Segoe UI. After this change, of course, there's still chance that the fonts won't get there in time for the initial render, but they _will_ load faster, potentially before first render, reducing CLS.

| Waterfall before | Waterfall after | 
| --- | --- |
| <img width="723" alt="image" src="https://github.com/rn-versions/rn-versions.github.io/assets/5426427/6f825bf2-2081-44fd-abd1-8cc53986d124"> | <img width="723" alt="image" src="https://github.com/rn-versions/rn-versions.github.io/assets/5426427/e877cb6e-688d-4b69-8d08-f23cf5a1c56d"> |

