### PR TITLE
Add Yarn cache to speed up CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache .yarn/cache
+        uses: actions/cache@v3
+        env:
+          cache-name: yarn-cache
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}
+
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/update-history.yml
+++ b/.github/workflows/update-history.yml
@@ -17,6 +17,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache .yarn/cache
+        uses: actions/cache@v3
+        env:
+          cache-name: yarn-cache
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}
+
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
On the first CI run, it won't have any effect (a negative one, if any, even). On the subsequent runs however, we should see installation time falling drastically.