### PR TITLE
Bump chalk from 4.1.2 to 5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "last 1 safari version"
   ],
   "devDependencies": {
-    "@types/chalk": "^2.2.0",
     "@types/node": "^12.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
@@ -44,7 +43,7 @@
     "axios-rate-limit": "^1.3.0",
     "axios-retry": "^3.2.3",
     "babel-eslint": "^10.0.0",
-    "chalk": "^4.1.2",
+    "chalk": "^5.3.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,15 +722,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chalk@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@types/chalk@npm:2.2.0"
-  dependencies:
-    chalk: "*"
-  checksum: 846437590d0bf0026d8c2f454e5d91a486becfabde61c0441025e791a0fed75304e143717bc4d025569394dcce5a32f2c53d97253d0c735ac1abae63f1b25c3e
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:^7.0.7":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
@@ -1296,14 +1287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:*":
-  version: 5.0.1
-  resolution: "chalk@npm:5.0.1"
-  checksum: 7b45300372b908f0471fbf7389ce2f5de8d85bb949026fd51a1b95b10d0ed32c7ed5aab36dd5e9d2bf3191867909b4404cef75c5f4d2d1daeeacd301dd280b76
-  languageName: node
-  linkType: hard
-
-"chalk@npm:5.3.0":
+"chalk@npm:5.3.0, chalk@npm:^5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80
@@ -1321,7 +1305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -4033,7 +4017,6 @@ __metadata:
   dependencies:
     "@fluentui/react": ^8.110.0
     "@fluentui/react-icons-mdl2": ^1.3.47
-    "@types/chalk": ^2.2.0
     "@types/node": ^12.0.0
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
@@ -4045,7 +4028,7 @@ __metadata:
     axios-rate-limit: ^1.3.0
     axios-retry: ^3.2.3
     babel-eslint: ^10.0.0
-    chalk: ^4.1.2
+    chalk: ^5.3.0
     eslint: ^7.5.0
     eslint-config-prettier: ^8.3.0
     eslint-config-react-app: ^6.0.0


### PR DESCRIPTION
As chalk is now native TypeScript, @types/chalk was also removed.