### PR TITLE
Bump axios-retry from 3.2.3 to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/parser": "^4.0.0",
     "axios": "^0.23.0",
     "axios-rate-limit": "^1.3.0",
-    "axios-retry": "^3.2.3",
+    "axios-retry": "^3.7.0",
     "babel-eslint": "^10.0.0",
     "chalk": "^5.3.0",
     "eslint": "^7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,13 +1166,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios-retry@npm:^3.2.3":
-  version: 3.2.4
-  resolution: "axios-retry@npm:3.2.4"
+"axios-retry@npm:^3.7.0":
+  version: 3.8.0
+  resolution: "axios-retry@npm:3.8.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     is-retry-allowed: ^2.2.0
-  checksum: 2a917a87cce979955f0f3b8c66e77e45913ae9ce39419028d9966af4d55eac8d7d8ab03d39bd864f62f8af48197b3e3938cef310cd5d85caab6b53b2d49e22ac
+  checksum: 448d951b971ccd35eaedc0f10ff1129a6bf2b3dfe13ce57749809bd37975332ae0e906ea4e67a41c9c98215bb1bf8a554e6880f1272419c758f91e4d68ca6b55
   languageName: node
   linkType: hard
 
@@ -4026,7 +4026,7 @@ __metadata:
     "@typescript-eslint/parser": ^4.0.0
     axios: ^0.23.0
     axios-rate-limit: ^1.3.0
-    axios-retry: ^3.2.3
+    axios-retry: ^3.7.0
     babel-eslint: ^10.0.0
     chalk: ^5.3.0
     eslint: ^7.5.0


### PR DESCRIPTION
This package would fail if TypeScript was updated to 5.x.