### PR TITLE
Fix JSON written in wrong paths if path contains spaces

### DIFF
--- a/scripts/generateAssets.ts
+++ b/scripts/generateAssets.ts
@@ -7,7 +7,7 @@ import createAxiosInstance from "./helper/createAxiosInstance.js";
 import { PackageIdentifier, packages } from "../src/PackageDescription.js";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = decodeURI(path.dirname(new URL(import.meta.url).pathname));
 
 type VersionIndex = string;
 

--- a/scripts/updateHistory.ts
+++ b/scripts/updateHistory.ts
@@ -8,7 +8,7 @@ import createAxiosInstance from "./helper/createAxiosInstance.js";
 import { PackageIdentifier, packages } from "../src/PackageDescription.js";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = decodeURI(path.dirname(new URL(import.meta.url).pathname));
 
 type NpmApiStats = {
   package: string;


### PR DESCRIPTION
Kind of an edge case, but:  if path contained spaces, `__dirname` had `%20`s in its value, unescaped, causing trouble.