### PR TITLE
Filter out bad expo version numbers

### DIFF
--- a/src/PackageDescription.ts
+++ b/src/PackageDescription.ts
@@ -100,7 +100,8 @@ const packagesLiteral = {
   },
   expo: {
     friendlyName: "Expo",
-    versionFilter: (v: string) => minVersion(v, "38.0"),
+    versionFilter: (v: string) =>
+      v !== "0.1.0pre" && v !== "0.1.0pre2" && minVersion(v, "38.0"),
   },
   react: {
     friendlyName: "React",


### PR DESCRIPTION
Turns out expo once released 0.1.0pre and 0.1.0pre2, which are not valid semver. Parsing historical data for these causes a crash.