### PR TITLE
Trim trailing `-1`s when generating assets

### DIFF
--- a/scripts/generateAssets.ts
+++ b/scripts/generateAssets.ts
@@ -122,10 +122,7 @@ async function generateWebpageAssets() {
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         }).map((_, i) => newPoint.versionCounts[i] ?? -1);
         // Trim trailing -1s
-        while (
-          optimizedVersionCounts.length > 0 &&
-          optimizedVersionCounts[optimizedVersionCounts.length - 1] === -1
-        ) {
+        while (optimizedVersionCounts.at(-1) === -1) {
           optimizedVersionCounts.pop();
         }
         const after = JSON.stringify(optimizedVersionCounts);

--- a/scripts/generateAssets.ts
+++ b/scripts/generateAssets.ts
@@ -121,6 +121,13 @@ async function generateWebpageAssets() {
           length: versions.length,
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         }).map((_, i) => newPoint.versionCounts[i] ?? -1);
+        // Trim trailing -1s
+        while (
+          optimizedVersionCounts.length > 0 &&
+          optimizedVersionCounts[optimizedVersionCounts.length - 1] === -1
+        ) {
+          optimizedVersionCounts.pop();
+        }
         const after = JSON.stringify(optimizedVersionCounts);
 
         if (after.length < before.length) {


### PR DESCRIPTION
In case `versionCounts` are stored as an array (an optimization that landed in #40), we then read the array by skipping all array items with `-1`s. While this is already more optimal than an object in many cases, I've noticed that we could just trim trailing chains of `-1`s in this array, not only reducing the amount of data, but also making it faster to parse. Not a huge win, but it's there, so why not take it?

generated_assets directory size
before: 3 840 513 B
after: 3 707 218 B (-3.5%)