### PR TITLE
Update Yarn cache location in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache .yarn/cache
+      - name: Cache Yarn cache
         uses: actions/cache@v3
         env:
           cache-name: yarn-cache
         with:
-          path: .yarn/cache
+          path: ~/.yarn/berry/cache
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}
@@ -48,12 +48,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache .yarn/cache
+      - name: Cache Yarn cache
         uses: actions/cache@v3
         env:
           cache-name: yarn-cache
         with:
-          path: .yarn/cache
+          path: ~/.yarn/berry/cache
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}
@@ -82,12 +82,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache .yarn/cache
+      - name: Cache Yarn cache
         uses: actions/cache@v3
         env:
           cache-name: yarn-cache
         with:
-          path: .yarn/cache
+          path: ~/.yarn/berry/cache
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}


### PR DESCRIPTION
In Yarn 4, by default, global cache is utilized, as opposed to `.yarn/cache` directory in repository root in Yarn 2 and 3.