### PR TITLE
Add tracking for react-native-visionos

### DIFF
--- a/src/HistoryReader.ts
+++ b/src/HistoryReader.ts
@@ -111,6 +111,10 @@ export default class HistoryReader {
         return import("./generated_assets/react-native-web.json");
       case "react-native-windows":
         return import("./generated_assets/react-native-windows.json");
+      case "@callstack/react-native-visionos":
+        return import(
+          "./generated_assets/@callstack_react-native-visionos.json"
+        );
       case "expo":
         return import("./generated_assets/expo.json");
       case "react":

--- a/src/PackageDescription.ts
+++ b/src/PackageDescription.ts
@@ -76,6 +76,11 @@ const packagesLiteral = {
     versionFilter: (v: string) => minVersion(v, "17.0") || isNightly(v),
     versionLabeler: (v: string) => (v === "0.0" ? "experimental" : v),
   },
+  "@callstack/react-native-visionos": {
+    friendlyName: "React Native visionOS",
+    popularity: 2_100,
+    versionFilter: (v: string) => minVersion(v, "0.73"),
+  },
 };
 
 export const packages: Record<PackageIdentifier, PackageDescription> =

--- a/src/generated_assets/@callstack_react-native-visionos.json
+++ b/src/generated_assets/@callstack_react-native-visionos.json
@@ -1,0 +1,1 @@
+{"versions":["0.73.6"],"points":[{"date":19784,"versionCounts":[112]}]}


### PR DESCRIPTION
Closes #74 

Added tracking for `react-native-visionos`.

<img width="1276" alt="Screenshot 2024-03-01 at 19 04 50" src="https://github.com/rn-versions/rn-versions.github.io/assets/13985840/0fa2dd34-0d82-4d1e-bc35-4acb7f213802">
